### PR TITLE
[Search] feat: 검색 피드백 반영

### DIFF
--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/SearchViewController/SearchViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/SearchViewController/SearchViewController+DataSource.swift
@@ -25,6 +25,13 @@ extension SearchViewController {
         dataSource.apply(snapshot)
     }
     
+    func emptySnashot() {
+        snapshot = Snapshot()
+        snapshot.appendSections([0])
+        snapshot.appendItems([])
+        dataSource.apply(snapshot, animatingDifferences: true)
+    }
+    
     func filteredSnapshot(searchWord word: String) {
         let filteredItems = samples.filter{ $0.title.contains(word) }
         snapshot = Snapshot()

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/SearchViewController/SearchViewController+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/SearchViewController/SearchViewController+Delegate.swift
@@ -20,8 +20,6 @@ extension SearchViewController: UISearchBarDelegate {
     }
     
     func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
-        if let searchWord = searchBar.text {
-            filteredSnapshot(searchWord: searchWord)
-        }
+        emptySnashot()
     }
 }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/SearchViewController/SearchViewController+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/SearchViewController/SearchViewController+Delegate.swift
@@ -19,4 +19,9 @@ extension SearchViewController: UISearchBarDelegate {
         initialSnapshot()
     }
     
+    func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
+        if let searchWord = searchBar.text {
+            filteredSnapshot(searchWord: searchWord)
+        }
+    }
 }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/SearchViewControllerWithAccessibility/SearchViewControllerWithAccessibility+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/SearchViewControllerWithAccessibility/SearchViewControllerWithAccessibility+DataSource.swift
@@ -46,7 +46,7 @@ extension SearchViewControllerWithAccessibility {
     
     func accessibilityAnnounceSearchResult(for list: [Book]) {
         if UIAccessibility.isVoiceOverRunning {
-            let annuouncement = "\(list.count)개의 검색 결과로 제한됨"
+            let annuouncement = "\(list.count)개 검색 결과 제안됨"
             UIAccessibility.post(notification: .announcement, argument: annuouncement)
         }
     }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/SearchViewControllerWithAccessibility/SearchViewControllerWithAccessibility+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/SearchViewControllerWithAccessibility/SearchViewControllerWithAccessibility+DataSource.swift
@@ -27,6 +27,13 @@ extension SearchViewControllerWithAccessibility {
         accessibilityAnnounceSearchResult(for: samples)
     }
     
+    func emptySnashot() {
+        snapshot = Snapshot()
+        snapshot.appendSections([0])
+        snapshot.appendItems([])
+        dataSource.apply(snapshot, animatingDifferences: true)
+    }
+    
     func filteredSnapshot(searchWord word: String) {
         let filteredItems = samples.filter{ $0.title.contains(word) }
         snapshot = Snapshot()

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/SearchViewControllerWithAccessibility/SearchViewControllerWithAccessibility+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/SearchViewControllerWithAccessibility/SearchViewControllerWithAccessibility+Delegate.swift
@@ -19,4 +19,9 @@ extension SearchViewControllerWithAccessibility: UISearchBarDelegate {
         initialSnapshot()
     }
     
+    func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
+        if let searchWord = searchBar.text {
+            filteredSnapshot(searchWord: searchWord)
+        }
+    }
 }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/SearchViewControllerWithAccessibility/SearchViewControllerWithAccessibility+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Text/SearchViewControllerWithAccessibility/SearchViewControllerWithAccessibility+Delegate.swift
@@ -20,8 +20,6 @@ extension SearchViewControllerWithAccessibility: UISearchBarDelegate {
     }
     
     func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
-        if let searchWord = searchBar.text {
-            filteredSnapshot(searchWord: searchWord)
-        }
+        emptySnashot()
     }
 }


### PR DESCRIPTION
- emptySnapshot 로직으로 검색 결과 없는 경우 구현
    - 검색바 최초 활성화 시(편집) 검색 목록 초기화(검색된 데이터가 없도록)
    - 검색바 최초 활성화 시(편집) 제안 문구 안 나오도록

- 검색 결과 안내 문구 변경 "0개 검색 결과 제안됨"

<br>

| 검색바 최초 활성화 | 검색 결과 안내 문구 변경 |
| ----- | ----- |
| <img src = "https://github.com/user-attachments/assets/64b600a1-118b-493a-8d64-019da8f2c16f" width = 200 height = 400> |  <img src = "https://github.com/user-attachments/assets/ba7c50db-807d-4630-8beb-6d6543a00316" width = 200 height = 400> |

<br>

<br>




#51