### PR TITLE
[ DateAndTime ] feat: 오늘/공휴일 기호 표시

### DIFF
--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		4E31E0F02C927024004C4979 /* DateFormatterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E31E0EF2C927024004C4979 /* DateFormatterManager.swift */; };
 		4E31E0F32C927621004C4979 /* DateAndTimeViewController+Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E31E0F22C927621004C4979 /* DateAndTimeViewController+Action.swift */; };
 		4E612E532CB4BB09004FAFA0 /* DynamicTypeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E612E522CB4BB09004FAFA0 /* DynamicTypeable.swift */; };
+		4E612E552CB502E9004FAFA0 /* PublicHoliday.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E612E542CB502E9004FAFA0 /* PublicHoliday.swift */; };
 		4E855F542CACE15C008CDB3B /* DefaultCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E855F532CACE15C008CDB3B /* DefaultCollectionViewController.swift */; };
 		4E855F562CACE184008CDB3B /* DefaultCollectionViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E855F552CACE184008CDB3B /* DefaultCollectionViewController+DataSource.swift */; };
 		4E855F582CACE1C0008CDB3B /* DefaultCollectionViewController+ListLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E855F572CACE1C0008CDB3B /* DefaultCollectionViewController+ListLayout.swift */; };
@@ -103,6 +104,7 @@
 		4E31E0EF2C927024004C4979 /* DateFormatterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatterManager.swift; sourceTree = "<group>"; };
 		4E31E0F22C927621004C4979 /* DateAndTimeViewController+Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateAndTimeViewController+Action.swift"; sourceTree = "<group>"; };
 		4E612E522CB4BB09004FAFA0 /* DynamicTypeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTypeable.swift; sourceTree = "<group>"; };
+		4E612E542CB502E9004FAFA0 /* PublicHoliday.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicHoliday.swift; sourceTree = "<group>"; };
 		4E855F532CACE15C008CDB3B /* DefaultCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCollectionViewController.swift; sourceTree = "<group>"; };
 		4E855F552CACE184008CDB3B /* DefaultCollectionViewController+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DefaultCollectionViewController+DataSource.swift"; sourceTree = "<group>"; };
 		4E855F572CACE1C0008CDB3B /* DefaultCollectionViewController+ListLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DefaultCollectionViewController+ListLayout.swift"; sourceTree = "<group>"; };
@@ -278,6 +280,7 @@
 				4E0AB03E2C9BAB9700B8A89C /* Detail.swift */,
 				4EC52B132CA1ABC0007E07D6 /* Book.swift */,
 				4E0925182CA4EC5D00474A16 /* WiFi.swift */,
+				4E612E542CB502E9004FAFA0 /* PublicHoliday.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -590,6 +593,7 @@
 				4E0AB0522C9BF02500B8A89C /* SearchViewController+DataSource.swift in Sources */,
 				4E0AB0542C9BF19C00B8A89C /* SearchViewController+Delegate.swift in Sources */,
 				14F7FC442CB2C8EC00F3FA61 /* SearchViewControllerWithAccessibility+Updating.swift in Sources */,
+				4E612E552CB502E9004FAFA0 /* PublicHoliday.swift in Sources */,
 				4EC51C9C2C91295200385BD0 /* Outline.swift in Sources */,
 				4EF982172C93FCDC00809294 /* AlertViewController+Action.swift in Sources */,
 				4E0AB0502C9BEF2800B8A89C /* SearchViewController.swift in Sources */,

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/DateAndTime/DateAndTimeViewController/DateAndTimeViewController+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/DateAndTime/DateAndTimeViewController/DateAndTimeViewController+Delegate.swift
@@ -10,12 +10,22 @@ import UIKit
 extension DateAndTimeViewController: UICalendarViewDelegate {
     func calendarView(_ calendarView: UICalendarView, decorationFor dateComponents: DateComponents) -> UICalendarView.Decoration? {
         
+        let todayConponents = Calendar.current.dateComponents([.year, .month, .day], from: Date())
         let publicHolidayComponentsList = publicHolidays.map{
-            let date = Calendar.current.date(byAdding: .day, value: 0, to: $0.locdate)!
-            return Calendar.current.dateComponents([.year, .month, .day], from: date)
+            Calendar.current.dateComponents([.year, .month, .day], from: $0.locdate)
         }
         
-        if let index = publicHolidayComponentsList.firstIndex(where: {
+        if todayConponents.year == dateComponents.year, todayConponents.month == dateComponents.month, todayConponents.day == dateComponents.day {
+            return UICalendarView.Decoration.customView {
+                let label = UILabel()
+                label.text = "●"
+                label.textColor = .blue
+                label.font = UIFont.preferredFont(forTextStyle: .caption2)
+                label.accessibilityLabel = String()
+                return label
+            }
+        }
+        else if let index = publicHolidayComponentsList.firstIndex(where: {
             $0.year == dateComponents.year && $0.month == dateComponents.month && $0.day == dateComponents.day
         }) {
             return .customView {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/DateAndTime/DateAndTimeViewController/DateAndTimeViewController+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/DateAndTime/DateAndTimeViewController/DateAndTimeViewController+Delegate.swift
@@ -7,7 +7,32 @@
 
 import UIKit
 
-extension DateAndTimeViewController: UICalendarViewDelegate, UICalendarSelectionSingleDateDelegate {
+extension DateAndTimeViewController: UICalendarViewDelegate {
+    func calendarView(_ calendarView: UICalendarView, decorationFor dateComponents: DateComponents) -> UICalendarView.Decoration? {
+        
+        let publicHolidayComponentsList = publicHolidays.map{
+            let date = Calendar.current.date(byAdding: .day, value: 0, to: $0.locdate)!
+            return Calendar.current.dateComponents([.year, .month, .day], from: date)
+        }
+        
+        if let index = publicHolidayComponentsList.firstIndex(where: {
+            $0.year == dateComponents.year && $0.month == dateComponents.month && $0.day == dateComponents.day
+        }) {
+            return .customView {
+                let dateNameLabel = UILabel()
+                dateNameLabel.text = self.publicHolidays[index].dateName
+                dateNameLabel.backgroundColor = .green
+                dateNameLabel.font = UIFont.preferredFont(forTextStyle: .caption2)
+                return dateNameLabel
+            }
+        }
+        
+        return nil
+    }
+    
+}
+
+extension DateAndTimeViewController: UICalendarSelectionSingleDateDelegate {
     
     func dateSelection(_ selection: UICalendarSelectionSingleDate, didSelectDate dateComponents: DateComponents?) {
         selectedData = dateComponents

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/DateAndTime/DateAndTimeViewController/DateAndTimeViewController+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/DateAndTime/DateAndTimeViewController/DateAndTimeViewController+Delegate.swift
@@ -23,6 +23,7 @@ extension DateAndTimeViewController: UICalendarViewDelegate {
                 dateNameLabel.text = self.publicHolidays[index].dateName
                 dateNameLabel.backgroundColor = .green
                 dateNameLabel.font = UIFont.preferredFont(forTextStyle: .caption2)
+                dateNameLabel.accessibilityValue = "공휴일"
                 return dateNameLabel
             }
         }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/DateAndTime/DateAndTimeViewController/DateAndTimeViewController.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/DateAndTime/DateAndTimeViewController/DateAndTimeViewController.swift
@@ -29,6 +29,7 @@ final class DateAndTimeViewController: DefaultCollectionViewController {
     
     var selectedData: DateComponents? = nil
     var dates: Set<DateComponents> = []
+    var publicHolidays = PublicHoliday.samples
     
     private lazy var dateBoxView = ComponentBoxView([labelForDatePicker, datePicker])
     private lazy var labelForDatePicker = UILabel()

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Models/Entities/PublicHoliday.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Models/Entities/PublicHoliday.swift
@@ -1,0 +1,21 @@
+//
+//  PublicHoliday.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 링키지랩 on 10/8/24.
+//
+
+import Foundation
+
+struct PublicHoliday {
+    let dateName: String
+    let locdate: Date
+}
+
+extension PublicHoliday {
+    static let samples = [
+        PublicHoliday(dateName: "국군의 날", locdate: Calendar.current.date(from: DateComponents(year: 2024, month: 10, day: 1)) ?? Date()),
+        PublicHoliday(dateName: "개천절", locdate: Calendar.current.date(from: DateComponents(year: 2024, month: 10, day: 3)) ?? Date()),
+        PublicHoliday(dateName: "한글날", locdate: Calendar.current.date(from: DateComponents(year: 2024, month: 10, day: 9)) ?? Date())
+    ]
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/DefaultListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/DefaultListCell.swift
@@ -54,6 +54,7 @@ private extension DefaultListCell {
             
             tagLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 5),
             tagLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            tagLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: 30),
             
             subtitleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
             subtitleLabel.trailingAnchor.constraint(equalTo: trailingAnchor),

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/DefaultListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/DefaultListCell.swift
@@ -51,6 +51,7 @@ private extension DefaultListCell {
             titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
             titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
             titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: 5),
+            titleLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: 30),
             
             tagLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 5),
             tagLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -59,6 +60,7 @@ private extension DefaultListCell {
             subtitleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
             subtitleLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
             subtitleLabel.topAnchor.constraint(equalTo: tagLabel.bottomAnchor, constant: 5),
+            subtitleLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: 30),
             
             view.leadingAnchor.constraint(equalTo: leadingAnchor),
             view.trailingAnchor.constraint(equalTo: trailingAnchor),


### PR DESCRIPTION
색 구분이 어려운 사용자들을 위해 도형, 기호 등을 사용해 오늘/공휴일을 표시한다

- PublicHoliday 모델 생성 및 샘플 데이터 추가
- 공휴일
    - 10월 임시 데이터 생성
    - 해당 날짜 연결
- 오늘
    - 기호 표시
- DefaultListCell: 하위 view들의 높이 설정(view 잘림 오류 수정)

<br>

| 검색바 최초 활성화 | 검색 결과 안내 문구 변경 |
| ----- | ----- |
| <img src = "https://github.com/user-attachments/assets/85e3e39b-ff4d-46d4-b1bc-0a5853214a4a" width = 200 height = 400> |  <img src = "https://github.com/user-attachments/assets/ab2384d1-dd56-421d-bffe-9e63b80f5e61" width = 200 height = 400> |

<br>

<br>





#53 