### PR TITLE
[ List ] ui/feat: 멜론 차트 탐색

### DIFF
--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		144FC6ED2CBCB0FF00CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6EC2CBCB0FF00CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Delegate.swift */; };
 		144FC6EF2CBCB1E800CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6EE2CBCB1E800CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Action.swift */; };
 		144FC6F32CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F22CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift */; };
+		144FC6F52CBCD87300CC75FE /* BorderedListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F42CBCD87300CC75FE /* BorderedListCell.swift */; };
+		144FC6F72CBCDAB100CC75FE /* AdjustableForAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F62CBCDAB100CC75FE /* AdjustableForAccessibility.swift */; };
 		14B1303C2CAED6D500877314 /* GrabberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B1303B2CAED6D500877314 /* GrabberView.swift */; };
 		14F7FC3B2CB2AC4D00F3FA61 /* PageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */; };
 		14F7FC3E2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */; };
@@ -107,6 +109,8 @@
 		144FC6EC2CBCB0FF00CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewControllerWithAccessibility+Delegate.swift"; sourceTree = "<group>"; };
 		144FC6EE2CBCB1E800CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewControllerWithAccessibility+Action.swift"; sourceTree = "<group>"; };
 		144FC6F22CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridTextCellWithAccessibility.swift; sourceTree = "<group>"; };
+		144FC6F42CBCD87300CC75FE /* BorderedListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BorderedListCell.swift; sourceTree = "<group>"; };
+		144FC6F62CBCDAB100CC75FE /* AdjustableForAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustableForAccessibility.swift; sourceTree = "<group>"; };
 		14B1303B2CAED6D500877314 /* GrabberView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GrabberView.swift; sourceTree = "<group>"; };
 		14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDetailViewController.swift; sourceTree = "<group>"; };
 		14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewControllerWithAccessibility.swift; sourceTree = "<group>"; };
@@ -249,6 +253,7 @@
 				4E0AB0442C9BC9CE00B8A89C /* ComponentBoxView.swift */,
 				4E0AB0462C9BD22200B8A89C /* DefaultTextField.swift */,
 				4EC52AF02CA13728007E07D6 /* GridTextCell.swift */,
+				144FC6F42CBCD87300CC75FE /* BorderedListCell.swift */,
 				144FC6F22CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift */,
 				4EC52AF22CA138D3007E07D6 /* TitleSupplementaryView.swift */,
 				4EC52AF42CA13925007E07D6 /* View+Constraints.swift */,
@@ -354,6 +359,7 @@
 			children = (
 				4E12CE4A2CA2482F004DF1EA /* Titleable.swift */,
 				4E612E522CB4BB09004FAFA0 /* DynamicTypeable.swift */,
+				144FC6F62CBCDAB100CC75FE /* AdjustableForAccessibility.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -642,6 +648,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				144FC6F52CBCD87300CC75FE /* BorderedListCell.swift in Sources */,
 				144564282CBB98720097DF89 /* MelonChartNavigationViewController+DataSource.swift in Sources */,
 				4E0AB03F2C9BAB9700B8A89C /* Detail.swift in Sources */,
 				4E855F542CACE15C008CDB3B /* DefaultCollectionViewController.swift in Sources */,
@@ -664,6 +671,7 @@
 				4EB123002CB793B100D771D3 /* ButtonSupplementaryView.swift in Sources */,
 				4EC52AFE2CA145C0007E07D6 /* TableViewController+DataSource.swift in Sources */,
 				1445642A2CBC00AA0097DF89 /* MelonChartNavigationViewControllerWithAccessibility.swift in Sources */,
+				144FC6F72CBCDAB100CC75FE /* AdjustableForAccessibility.swift in Sources */,
 				4ED71CE52CA6392F00A1A724 /* AccessibilityListCell.swift in Sources */,
 				4EC52AE12C9D1590007E07D6 /* SwitchViewController+DataSource.swift in Sources */,
 				4E0AB0492C9BDD9900B8A89C /* TextViewController.swift in Sources */,

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		144FC6F32CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F22CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift */; };
 		144FC6F52CBCD87300CC75FE /* BorderedListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F42CBCD87300CC75FE /* BorderedListCell.swift */; };
 		144FC6F72CBCDAB100CC75FE /* AdjustableForAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F62CBCDAB100CC75FE /* AdjustableForAccessibility.swift */; };
+		144FC6FA2CBCE8B000CC75FE /* InnerCollectionListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F92CBCE8B000CC75FE /* InnerCollectionListCell.swift */; };
 		14B1303C2CAED6D500877314 /* GrabberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B1303B2CAED6D500877314 /* GrabberView.swift */; };
 		14F7FC3B2CB2AC4D00F3FA61 /* PageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */; };
 		14F7FC3E2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */; };
@@ -111,6 +112,7 @@
 		144FC6F22CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridTextCellWithAccessibility.swift; sourceTree = "<group>"; };
 		144FC6F42CBCD87300CC75FE /* BorderedListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BorderedListCell.swift; sourceTree = "<group>"; };
 		144FC6F62CBCDAB100CC75FE /* AdjustableForAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustableForAccessibility.swift; sourceTree = "<group>"; };
+		144FC6F92CBCE8B000CC75FE /* InnerCollectionListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InnerCollectionListCell.swift; sourceTree = "<group>"; };
 		14B1303B2CAED6D500877314 /* GrabberView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GrabberView.swift; sourceTree = "<group>"; };
 		14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDetailViewController.swift; sourceTree = "<group>"; };
 		14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewControllerWithAccessibility.swift; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 				144FC6EE2CBCB1E800CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Action.swift */,
 				1445642D2CBC00DF0097DF89 /* MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift */,
 				1445642F2CBC00E90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+Type.swift */,
+				144FC6F92CBCE8B000CC75FE /* InnerCollectionListCell.swift */,
 			);
 			path = MelonChartNavigationViewControllerWithAccessibility;
 			sourceTree = "<group>";
@@ -690,6 +693,7 @@
 				4EC52B0C2CA19D57007E07D6 /* PresentationAndMenuViewController.swift in Sources */,
 				4E855F562CACE184008CDB3B /* DefaultCollectionViewController+DataSource.swift in Sources */,
 				4E1BC4F72CAF7244001A29D5 /* SearchViewController+Updating.swift in Sources */,
+				144FC6FA2CBCE8B000CC75FE /* InnerCollectionListCell.swift in Sources */,
 				4EB122FA2CB7694300D771D3 /* NewsListCell.swift in Sources */,
 				4E285DBF2C8FE947007F286C /* ButtonAndSliderViewController+Action.swift in Sources */,
 				14F7FC422CB2C8DC00F3FA61 /* SearchViewControllerWithAccessibility+Delegate.swift in Sources */,

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		144564222CBB932B0097DF89 /* MelonChartNavigationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144564212CBB932B0097DF89 /* MelonChartNavigationViewController.swift */; };
+		144564242CBB941B0097DF89 /* MelonChartNavigationViewController+ListLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144564232CBB941B0097DF89 /* MelonChartNavigationViewController+ListLayout.swift */; };
+		144564262CBB959F0097DF89 /* MelonChartNavigationViewController+Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144564252CBB959F0097DF89 /* MelonChartNavigationViewController+Type.swift */; };
+		144564282CBB98720097DF89 /* MelonChartNavigationViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144564272CBB98720097DF89 /* MelonChartNavigationViewController+DataSource.swift */; };
 		14B1303C2CAED6D500877314 /* GrabberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B1303B2CAED6D500877314 /* GrabberView.swift */; };
 		14F7FC3B2CB2AC4D00F3FA61 /* PageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */; };
 		14F7FC3E2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */; };
@@ -85,6 +89,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		144564212CBB932B0097DF89 /* MelonChartNavigationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MelonChartNavigationViewController.swift; sourceTree = "<group>"; };
+		144564232CBB941B0097DF89 /* MelonChartNavigationViewController+ListLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewController+ListLayout.swift"; sourceTree = "<group>"; };
+		144564252CBB959F0097DF89 /* MelonChartNavigationViewController+Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewController+Type.swift"; sourceTree = "<group>"; };
+		144564272CBB98720097DF89 /* MelonChartNavigationViewController+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewController+DataSource.swift"; sourceTree = "<group>"; };
 		14B1303B2CAED6D500877314 /* GrabberView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GrabberView.swift; sourceTree = "<group>"; };
 		14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDetailViewController.swift; sourceTree = "<group>"; };
 		14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewControllerWithAccessibility.swift; sourceTree = "<group>"; };
@@ -176,6 +184,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		144564202CBB92DC0097DF89 /* MelonChartNavigationViewController */ = {
+			isa = PBXGroup;
+			children = (
+				144564212CBB932B0097DF89 /* MelonChartNavigationViewController.swift */,
+				144564272CBB98720097DF89 /* MelonChartNavigationViewController+DataSource.swift */,
+				144564232CBB941B0097DF89 /* MelonChartNavigationViewController+ListLayout.swift */,
+				144564252CBB959F0097DF89 /* MelonChartNavigationViewController+Type.swift */,
+			);
+			path = MelonChartNavigationViewController;
+			sourceTree = "<group>";
+		};
 		14F7FC3C2CB2C89300F3FA61 /* SearchViewControllerWithAccessibility */ = {
 			isa = PBXGroup;
 			children = (
@@ -453,6 +472,7 @@
 				4EC52B012CA151D4007E07D6 /* TableViewController */,
 				4E1306B72CB8B5B400ABA955 /* NewsListViewController */,
 				4E1306B82CB8B5C600ABA955 /* NewListViewControllerWithAccessibility */,
+				144564202CBB92DC0097DF89 /* MelonChartNavigationViewController */,
 			);
 			path = List;
 			sourceTree = "<group>";
@@ -593,6 +613,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				144564282CBB98720097DF89 /* MelonChartNavigationViewController+DataSource.swift in Sources */,
 				4E0AB03F2C9BAB9700B8A89C /* Detail.swift in Sources */,
 				4E855F542CACE15C008CDB3B /* DefaultCollectionViewController.swift in Sources */,
 				4E855F582CACE1C0008CDB3B /* DefaultCollectionViewController+ListLayout.swift in Sources */,
@@ -604,6 +625,7 @@
 				4EC52AE72C9D36F4007E07D6 /* ImageLoader.swift in Sources */,
 				4EC52AEB2CA11594007E07D6 /* DateAndTimeViewController+Delegate.swift in Sources */,
 				4EC52AEF2CA1359F007E07D6 /* CollectionViewController+DataSource.swift in Sources */,
+				144564222CBB932B0097DF89 /* MelonChartNavigationViewController.swift in Sources */,
 				4E12CE4D2CA27BD4004DF1EA /* DefaultWithScrollViewController.swift in Sources */,
 				4E285DC52C901C68007F286C /* StateViewController.swift in Sources */,
 				4EC51C952C911B8500385BD0 /* StateViewController+Action.swift in Sources */,
@@ -620,6 +642,7 @@
 				4E1BC4F92CAF87F9001A29D5 /* UIAccessibility+Focus.swift in Sources */,
 				4EC52AF72CA13A51007E07D6 /* CollectionView+ListLayout.swift in Sources */,
 				4EB122FC2CB7821A00D771D3 /* News.swift in Sources */,
+				144564242CBB941B0097DF89 /* MelonChartNavigationViewController+ListLayout.swift in Sources */,
 				4E31E0F32C927621004C4979 /* DateAndTimeViewController+Action.swift in Sources */,
 				4ECD49782C8E9B6000F3BEC7 /* AppDelegate.swift in Sources */,
 				4E0925192CA4EC5D00474A16 /* WiFi.swift in Sources */,
@@ -648,6 +671,7 @@
 				4EC52AF92CA13F3E007E07D6 /* CollectionViewController+Type.swift in Sources */,
 				4EC52AF12CA13728007E07D6 /* GridTextCell.swift in Sources */,
 				4E0AB0472C9BD22200B8A89C /* DefaultTextField.swift in Sources */,
+				144564262CBB959F0097DF89 /* MelonChartNavigationViewController+Type.swift in Sources */,
 				4EC52B092CA16D95007E07D6 /* PageViewController.swift in Sources */,
 				4EC52AFC2CA144D5007E07D6 /* TableViewController.swift in Sources */,
 				4EC52B142CA1ABC0007E07D6 /* Book.swift in Sources */,

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		144564302CBC00E90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1445642F2CBC00E90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+Type.swift */; };
 		144FC6ED2CBCB0FF00CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6EC2CBCB0FF00CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Delegate.swift */; };
 		144FC6EF2CBCB1E800CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6EE2CBCB1E800CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Action.swift */; };
+		144FC6F32CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6F22CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift */; };
 		14B1303C2CAED6D500877314 /* GrabberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B1303B2CAED6D500877314 /* GrabberView.swift */; };
 		14F7FC3B2CB2AC4D00F3FA61 /* PageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */; };
 		14F7FC3E2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */; };
@@ -105,6 +106,7 @@
 		1445642F2CBC00E90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewControllerWithAccessibility+Type.swift"; sourceTree = "<group>"; };
 		144FC6EC2CBCB0FF00CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewControllerWithAccessibility+Delegate.swift"; sourceTree = "<group>"; };
 		144FC6EE2CBCB1E800CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewControllerWithAccessibility+Action.swift"; sourceTree = "<group>"; };
+		144FC6F22CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridTextCellWithAccessibility.swift; sourceTree = "<group>"; };
 		14B1303B2CAED6D500877314 /* GrabberView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GrabberView.swift; sourceTree = "<group>"; };
 		14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDetailViewController.swift; sourceTree = "<group>"; };
 		14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewControllerWithAccessibility.swift; sourceTree = "<group>"; };
@@ -247,6 +249,7 @@
 				4E0AB0442C9BC9CE00B8A89C /* ComponentBoxView.swift */,
 				4E0AB0462C9BD22200B8A89C /* DefaultTextField.swift */,
 				4EC52AF02CA13728007E07D6 /* GridTextCell.swift */,
+				144FC6F22CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift */,
 				4EC52AF22CA138D3007E07D6 /* TitleSupplementaryView.swift */,
 				4EC52AF42CA13925007E07D6 /* View+Constraints.swift */,
 				4E12CE482CA244BC004DF1EA /* DefaultViewController.swift */,
@@ -668,6 +671,7 @@
 				4E12CE492CA244BC004DF1EA /* DefaultViewController.swift in Sources */,
 				4EC52AF32CA138D3007E07D6 /* TitleSupplementaryView.swift in Sources */,
 				4E1BC4F92CAF87F9001A29D5 /* UIAccessibility+Focus.swift in Sources */,
+				144FC6F32CBCBDAB00CC75FE /* GridTextCellWithAccessibility.swift in Sources */,
 				144564302CBC00E90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+Type.swift in Sources */,
 				4EC52AF72CA13A51007E07D6 /* CollectionView+ListLayout.swift in Sources */,
 				4EB122FC2CB7821A00D771D3 /* News.swift in Sources */,

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -11,6 +11,10 @@
 		144564242CBB941B0097DF89 /* MelonChartNavigationViewController+ListLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144564232CBB941B0097DF89 /* MelonChartNavigationViewController+ListLayout.swift */; };
 		144564262CBB959F0097DF89 /* MelonChartNavigationViewController+Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144564252CBB959F0097DF89 /* MelonChartNavigationViewController+Type.swift */; };
 		144564282CBB98720097DF89 /* MelonChartNavigationViewController+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144564272CBB98720097DF89 /* MelonChartNavigationViewController+DataSource.swift */; };
+		1445642A2CBC00AA0097DF89 /* MelonChartNavigationViewControllerWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144564292CBC00AA0097DF89 /* MelonChartNavigationViewControllerWithAccessibility.swift */; };
+		1445642C2CBC00B90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1445642B2CBC00B90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+DataSource.swift */; };
+		1445642E2CBC00DF0097DF89 /* MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1445642D2CBC00DF0097DF89 /* MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift */; };
+		144564302CBC00E90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1445642F2CBC00E90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+Type.swift */; };
 		14B1303C2CAED6D500877314 /* GrabberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B1303B2CAED6D500877314 /* GrabberView.swift */; };
 		14F7FC3B2CB2AC4D00F3FA61 /* PageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */; };
 		14F7FC3E2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */; };
@@ -93,6 +97,10 @@
 		144564232CBB941B0097DF89 /* MelonChartNavigationViewController+ListLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewController+ListLayout.swift"; sourceTree = "<group>"; };
 		144564252CBB959F0097DF89 /* MelonChartNavigationViewController+Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewController+Type.swift"; sourceTree = "<group>"; };
 		144564272CBB98720097DF89 /* MelonChartNavigationViewController+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewController+DataSource.swift"; sourceTree = "<group>"; };
+		144564292CBC00AA0097DF89 /* MelonChartNavigationViewControllerWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MelonChartNavigationViewControllerWithAccessibility.swift; sourceTree = "<group>"; };
+		1445642B2CBC00B90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewControllerWithAccessibility+DataSource.swift"; sourceTree = "<group>"; };
+		1445642D2CBC00DF0097DF89 /* MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift"; sourceTree = "<group>"; };
+		1445642F2CBC00E90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewControllerWithAccessibility+Type.swift"; sourceTree = "<group>"; };
 		14B1303B2CAED6D500877314 /* GrabberView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GrabberView.swift; sourceTree = "<group>"; };
 		14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDetailViewController.swift; sourceTree = "<group>"; };
 		14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewControllerWithAccessibility.swift; sourceTree = "<group>"; };
@@ -193,6 +201,17 @@
 				144564252CBB959F0097DF89 /* MelonChartNavigationViewController+Type.swift */,
 			);
 			path = MelonChartNavigationViewController;
+			sourceTree = "<group>";
+		};
+		144564312CBC015B0097DF89 /* MelonChartNavigationViewControllerWithAccessibility */ = {
+			isa = PBXGroup;
+			children = (
+				144564292CBC00AA0097DF89 /* MelonChartNavigationViewControllerWithAccessibility.swift */,
+				1445642B2CBC00B90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+DataSource.swift */,
+				1445642D2CBC00DF0097DF89 /* MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift */,
+				1445642F2CBC00E90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+Type.swift */,
+			);
+			path = MelonChartNavigationViewControllerWithAccessibility;
 			sourceTree = "<group>";
 		};
 		14F7FC3C2CB2C89300F3FA61 /* SearchViewControllerWithAccessibility */ = {
@@ -473,6 +492,7 @@
 				4E1306B72CB8B5B400ABA955 /* NewsListViewController */,
 				4E1306B82CB8B5C600ABA955 /* NewListViewControllerWithAccessibility */,
 				144564202CBB92DC0097DF89 /* MelonChartNavigationViewController */,
+				144564312CBC015B0097DF89 /* MelonChartNavigationViewControllerWithAccessibility */,
 			);
 			path = List;
 			sourceTree = "<group>";
@@ -629,10 +649,12 @@
 				4E12CE4D2CA27BD4004DF1EA /* DefaultWithScrollViewController.swift in Sources */,
 				4E285DC52C901C68007F286C /* StateViewController.swift in Sources */,
 				4EC51C952C911B8500385BD0 /* StateViewController+Action.swift in Sources */,
+				1445642C2CBC00B90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+DataSource.swift in Sources */,
 				4EC52B002CA14976007E07D6 /* TableViewController+Delegate.swift in Sources */,
 				4EC51C972C91226300385BD0 /* OutlineViewController.swift in Sources */,
 				4EB123002CB793B100D771D3 /* ButtonSupplementaryView.swift in Sources */,
 				4EC52AFE2CA145C0007E07D6 /* TableViewController+DataSource.swift in Sources */,
+				1445642A2CBC00AA0097DF89 /* MelonChartNavigationViewControllerWithAccessibility.swift in Sources */,
 				4ED71CE52CA6392F00A1A724 /* AccessibilityListCell.swift in Sources */,
 				4EC52AE12C9D1590007E07D6 /* SwitchViewController+DataSource.swift in Sources */,
 				4E0AB0492C9BDD9900B8A89C /* TextViewController.swift in Sources */,
@@ -640,6 +662,7 @@
 				4E12CE492CA244BC004DF1EA /* DefaultViewController.swift in Sources */,
 				4EC52AF32CA138D3007E07D6 /* TitleSupplementaryView.swift in Sources */,
 				4E1BC4F92CAF87F9001A29D5 /* UIAccessibility+Focus.swift in Sources */,
+				144564302CBC00E90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+Type.swift in Sources */,
 				4EC52AF72CA13A51007E07D6 /* CollectionView+ListLayout.swift in Sources */,
 				4EB122FC2CB7821A00D771D3 /* News.swift in Sources */,
 				144564242CBB941B0097DF89 /* MelonChartNavigationViewController+ListLayout.swift in Sources */,
@@ -679,6 +702,7 @@
 				4EC52AED2CA1352F007E07D6 /* CollectionViewController.swift in Sources */,
 				14F7FC472CB2CF6C00F3FA61 /* PageViewControllerWithAccessibility.swift in Sources */,
 				4EF982152C93E4DF00809294 /* AlertViewController.swift in Sources */,
+				1445642E2CBC00DF0097DF89 /* MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift in Sources */,
 				4E855F5C2CACF378008CDB3B /* DefaultListCell.swift in Sources */,
 				4E0AB0452C9BC9CE00B8A89C /* ComponentBoxView.swift in Sources */,
 				4EB123062CB7B57900D771D3 /* NewsListCellWithAccessibility.swift in Sources */,

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		1445642C2CBC00B90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1445642B2CBC00B90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+DataSource.swift */; };
 		1445642E2CBC00DF0097DF89 /* MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1445642D2CBC00DF0097DF89 /* MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift */; };
 		144564302CBC00E90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1445642F2CBC00E90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+Type.swift */; };
+		144FC6ED2CBCB0FF00CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6EC2CBCB0FF00CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Delegate.swift */; };
+		144FC6EF2CBCB1E800CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144FC6EE2CBCB1E800CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Action.swift */; };
 		14B1303C2CAED6D500877314 /* GrabberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B1303B2CAED6D500877314 /* GrabberView.swift */; };
 		14F7FC3B2CB2AC4D00F3FA61 /* PageDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */; };
 		14F7FC3E2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */; };
@@ -101,6 +103,8 @@
 		1445642B2CBC00B90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewControllerWithAccessibility+DataSource.swift"; sourceTree = "<group>"; };
 		1445642D2CBC00DF0097DF89 /* MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift"; sourceTree = "<group>"; };
 		1445642F2CBC00E90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewControllerWithAccessibility+Type.swift"; sourceTree = "<group>"; };
+		144FC6EC2CBCB0FF00CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewControllerWithAccessibility+Delegate.swift"; sourceTree = "<group>"; };
+		144FC6EE2CBCB1E800CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Action.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MelonChartNavigationViewControllerWithAccessibility+Action.swift"; sourceTree = "<group>"; };
 		14B1303B2CAED6D500877314 /* GrabberView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GrabberView.swift; sourceTree = "<group>"; };
 		14F7FC3A2CB2AC4D00F3FA61 /* PageDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageDetailViewController.swift; sourceTree = "<group>"; };
 		14F7FC3D2CB2C8C200F3FA61 /* SearchViewControllerWithAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewControllerWithAccessibility.swift; sourceTree = "<group>"; };
@@ -208,6 +212,8 @@
 			children = (
 				144564292CBC00AA0097DF89 /* MelonChartNavigationViewControllerWithAccessibility.swift */,
 				1445642B2CBC00B90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+DataSource.swift */,
+				144FC6EC2CBCB0FF00CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Delegate.swift */,
+				144FC6EE2CBCB1E800CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Action.swift */,
 				1445642D2CBC00DF0097DF89 /* MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift */,
 				1445642F2CBC00E90097DF89 /* MelonChartNavigationViewControllerWithAccessibility+Type.swift */,
 			);
@@ -677,6 +683,7 @@
 				14F7FC422CB2C8DC00F3FA61 /* SearchViewControllerWithAccessibility+Delegate.swift in Sources */,
 				4EC51C9F2C912AD800385BD0 /* OutLineViewController+Delegate.swift in Sources */,
 				4EC52B0E2CA1A5A9007E07D6 /* PresentationAndMenuViewController+Action.swift in Sources */,
+				144FC6EF2CBCB1E800CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Action.swift in Sources */,
 				4E0AB0522C9BF02500B8A89C /* SearchViewController+DataSource.swift in Sources */,
 				4E0AB0542C9BF19C00B8A89C /* SearchViewController+Delegate.swift in Sources */,
 				14F7FC442CB2C8EC00F3FA61 /* SearchViewControllerWithAccessibility+Updating.swift in Sources */,
@@ -704,6 +711,7 @@
 				4EF982152C93E4DF00809294 /* AlertViewController.swift in Sources */,
 				1445642E2CBC00DF0097DF89 /* MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift in Sources */,
 				4E855F5C2CACF378008CDB3B /* DefaultListCell.swift in Sources */,
+				144FC6ED2CBCB0FF00CC75FE /* MelonChartNavigationViewControllerWithAccessibility+Delegate.swift in Sources */,
 				4E0AB0452C9BC9CE00B8A89C /* ComponentBoxView.swift in Sources */,
 				4EB123062CB7B57900D771D3 /* NewsListCellWithAccessibility.swift in Sources */,
 				4E855F5A2CACE209008CDB3B /* DefaultCollectionViewController+Type.swift in Sources */,

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+DataSource.swift
@@ -1,0 +1,43 @@
+//
+//  MelonChartNavigationViewController+DataSource.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/13/24.
+//
+
+import UIKit
+
+extension MelonChartNavigationViewController {
+    typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
+    typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Item>
+    
+    func latestCellRegistrationHandler(cell: GridTextCell, indexPath: IndexPath, item: String) {
+        cell.text = item
+    }
+    
+    func chartCellRegistrationHandler(cell: UICollectionViewCell, indexPath: IndexPath, item: String) {
+        var config = UIListContentConfiguration.valueCell()
+        config.text = item
+        cell.contentConfiguration = config
+        cell.contentView.layer.borderWidth = 1
+        cell.contentView.layer.borderColor = UIColor.black.cgColor
+        
+    }
+    
+    func supplementaryRegistrationHandler(supplementaryView: TitleSupplementaryView, string: String, indexPath: IndexPath) {
+        let title = snapshot.sectionIdentifiers[indexPath.section].title
+        supplementaryView.title = title
+    }
+    
+    func updateSnapshot() {
+        let latestItems = ["노래1", "노래2", "노래3", "노래4", "노래5", "노래6", "노래7", "노래8"].map{ Item(latest: $0) }
+        let chartItems = ["노래1", "노래2", "노래3", "노래4", "노래5", "노래6", "노래7", "노래8"].map{ Item(chart: $0) }
+        
+        snapshot = Snapshot()
+        snapshot.appendSections([.latest, .chart])
+        snapshot.appendItems(latestItems, toSection: .latest)
+        snapshot.appendItems(chartItems, toSection: .chart)
+        dataSource.apply(snapshot)
+    }
+    
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+DataSource.swift
@@ -30,8 +30,8 @@ extension MelonChartNavigationViewController {
     }
     
     func updateSnapshot() {
-        let latestItems = ["노래1", "노래2", "노래3", "노래4", "노래5", "노래6", "노래7", "노래8"].map{ Item(latest: $0) }
-        let chartItems = ["노래1", "노래2", "노래3", "노래4", "노래5", "노래6", "노래7", "노래8"].map{ Item(chart: $0) }
+        let latestItems = books.map{ Item(latest: $0.title) }
+        let chartItems = books.map{ Item(chart: $0.title) }
         
         snapshot = Snapshot()
         snapshot.appendSections([.latest, .chart])

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+ListLayout.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+ListLayout.swift
@@ -1,0 +1,75 @@
+//
+//  MelonChartNavigationViewController+ListLayout.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/13/24.
+//
+
+import UIKit
+
+// MARK: CollectionView Layout
+extension MelonChartNavigationViewController {
+    
+    func layout() -> UICollectionViewLayout {
+        let configuration = UICollectionViewCompositionalLayoutConfiguration()
+        configuration.interSectionSpacing = 20
+        return UICollectionViewCompositionalLayout(sectionProvider: sectionProviderHandler, configuration: configuration)
+    }
+    
+    func sectionProviderHandler( sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
+        guard let section = Section(rawValue: sectionIndex) else {
+            fatalError("Unknown Section")
+        }
+        
+        switch section {
+        case .latest:
+            return sectionForLatest()
+        case .chart:
+            return sectionForChart()
+        }
+    }
+    
+    func sectionForLatest() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.48))
+        let nestedGroupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.48), heightDimension: .fractionalHeight(1.0))
+        let containerGroupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.95), heightDimension: .absolute(480))
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let nestedGroup = NSCollectionLayoutGroup.vertical(layoutSize: nestedGroupSize, repeatingSubitem: item, count: 2)
+        nestedGroup.interItemSpacing = NSCollectionLayoutSpacing.fixed(10)
+        
+        let containerGroup = NSCollectionLayoutGroup.horizontal(layoutSize: containerGroupSize, repeatingSubitem: nestedGroup, count: 2)
+        containerGroup.interItemSpacing = NSCollectionLayoutSpacing.fixed(10)
+        
+        let section = NSCollectionLayoutSection(group: containerGroup)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0)
+        section.boundarySupplementaryItems = [titleBoundarySupplementaryItem()]
+        section.orthogonalScrollingBehavior = .continuous
+        
+        return section
+    }
+    
+    func sectionForChart() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.9), heightDimension: .fractionalHeight(0.9))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.9), heightDimension: .estimated(80))
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, repeatingSubitem: item, count: 3)
+        group.interItemSpacing = .fixed(5)
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0)
+        section.boundarySupplementaryItems = [titleBoundarySupplementaryItem()]
+        section.orthogonalScrollingBehavior = .groupPaging
+        
+        return section
+    }
+    
+    func titleBoundarySupplementaryItem() -> NSCollectionLayoutBoundarySupplementaryItem {
+        let titleSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                              heightDimension: .estimated(50))
+        return NSCollectionLayoutBoundarySupplementaryItem(layoutSize: titleSize, elementKind: Supplementary.title
+            .name, alignment: .top)
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+Type.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController+Type.swift
@@ -1,0 +1,48 @@
+//
+//  MelonChartNavigationViewController+Type.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/13/24.
+//
+
+
+import Foundation
+
+//MARK: Types for DataSource
+extension MelonChartNavigationViewController {
+    enum Section: Int {
+        case latest, chart
+        
+        var title: String {
+            switch self {
+            case .latest:
+                return "Latest"
+            case .chart:
+                return "Chart"
+            }
+        }
+    }
+    
+    struct Item: Hashable {
+        let latest: String?
+        let chart: String?
+        
+        init(latest: String?) {
+            self.latest = latest
+            self.chart = nil
+        }
+        
+        init(chart: String?) {
+            self.chart = chart
+            self.latest = nil
+        }
+    }
+    
+    enum Supplementary: String {
+        case title = "title-element-kind"
+        
+        var name: String {
+            self.rawValue
+        }
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController.swift
@@ -1,0 +1,62 @@
+//
+//  MelonChartNavigationViewController.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/13/24.
+//
+
+import UIKit
+
+final class MelonChartNavigationViewController: DefaultViewController {
+    
+    var dataSource: DataSource!
+    var snapshot: Snapshot!
+    
+    private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
+    
+    // MARK: LifeCycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        configureSubviews()
+        configureView()
+        configureDataSource()
+    }
+}
+
+// MARK: Configuration
+private extension MelonChartNavigationViewController {
+    func configureSubviews() {
+        collectionView.contentInset = UIEdgeInsets(top: 10, left: 10, bottom: 20, right: -10)
+    }
+    
+    func configureView() {
+        view.addPinnedSubview(collectionView, height: nil)
+    }
+    
+    func configureDataSource() {
+        let latestCellRegistration = UICollectionView.CellRegistration(handler: latestCellRegistrationHandler)
+        let chartCellRegistration = UICollectionView.CellRegistration(handler: chartCellRegistrationHandler)
+        
+        dataSource = DataSource(collectionView: collectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
+            guard let section = Section(rawValue: indexPath.section) else {
+                fatalError("Unknown section")
+            }
+            switch section {
+            case .latest:
+                return collectionView.dequeueConfiguredReusableCell(using: latestCellRegistration, for: indexPath, item: itemIdentifier.latest)
+            case .chart:
+                return collectionView.dequeueConfiguredReusableCell(using: chartCellRegistration, for: indexPath, item: itemIdentifier.chart)
+            }
+        })
+        
+        let supplementaryRegistration = UICollectionView.SupplementaryRegistration(elementKind: Supplementary.title
+            .name, handler: supplementaryRegistrationHandler)
+        dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
+            return collectionView.dequeueConfiguredReusableSupplementary(using: supplementaryRegistration, for: indexPath)
+        }
+        
+        updateSnapshot()
+        collectionView.dataSource = dataSource
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController.swift
@@ -17,6 +17,7 @@ final class MelonChartNavigationViewController: DefaultViewController {
     // MARK: LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        isSettingFocus = false
         
         configureSubviews()
         configureView()

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewController/MelonChartNavigationViewController.swift
@@ -11,6 +11,7 @@ final class MelonChartNavigationViewController: DefaultViewController {
     
     var dataSource: DataSource!
     var snapshot: Snapshot!
+    var books = Book.samples
     
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
     

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/InnerCollectionListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/InnerCollectionListCell.swift
@@ -1,0 +1,64 @@
+//
+//  InnerCollectionListCell.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/14/24.
+//
+
+import UIKit
+
+final class InnerCollectionListCell: UICollectionViewCell {
+    
+    var dataSource: UICollectionViewDiffableDataSource<Int, String>!
+    var books = Book.samples
+    
+    lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureContentView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension InnerCollectionListCell {
+    
+    func configureContentView() {
+        contentView.addPinnedSubview(collectionView, height: nil)
+        
+        let cellRegistration = UICollectionView.CellRegistration(handler: cellRegistrationHandler)
+        
+        dataSource = UICollectionViewDiffableDataSource<Int, String>(collectionView: collectionView) { collectionView,indexPath,itemIdentifier in
+            return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: itemIdentifier)
+        }
+        
+        var snapshot = NSDiffableDataSourceSnapshot<Int, String>()
+        snapshot.appendSections([0])
+        snapshot.appendItems(books.map({$0.title}))
+        dataSource.apply(snapshot)
+        collectionView.dataSource = dataSource
+    }
+    
+    func layout() -> UICollectionViewLayout {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.5))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, repeatingSubitem: item, count: 2)
+        group.interItemSpacing = .flexible(5)
+        let section = NSCollectionLayoutSection(group: group)
+        section.orthogonalScrollingBehavior = .continuous
+        section.interGroupSpacing = 10
+        
+        return UICollectionViewCompositionalLayout(section: section)
+    }
+    
+    func cellRegistrationHandler(cell: BorderedListCell, indexPath: IndexPath, item: String) {
+        cell.rank = indexPath.item
+        cell.text = item
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/InnerCollectionListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/InnerCollectionListCell.swift
@@ -11,6 +11,8 @@ final class InnerCollectionListCell: UICollectionViewCell {
     
     var dataSource: UICollectionViewDiffableDataSource<Int, String>!
     var books = Book.samples
+    weak var delegate: AdjustableForAccessibility?
+    private var currentPageOfCustom = 0
     
     lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
     
@@ -22,6 +24,15 @@ final class InnerCollectionListCell: UICollectionViewCell {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func accessibilityIncrement() {
+        delegate?.adjustableIncrement(self)
+        
+    }
+    
+    override func accessibilityDecrement() {
+        delegate?.adjustableDecrement(self)
     }
 }
 
@@ -58,7 +69,14 @@ private extension InnerCollectionListCell {
     }
     
     func cellRegistrationHandler(cell: BorderedListCell, indexPath: IndexPath, item: String) {
-        cell.rank = indexPath.item
+        cell.rank = indexPath.item + 1
         cell.text = item
+    }
+    
+    func configureAccessibilityValue(current index: Int) {
+        let label = books[index].title
+        let value = "총 \(books.count) 페이지 중 \(index + 1) 페이지"
+        let descriptions = [label, value]
+        collectionView.accessibilityValue = descriptions.compactMap({ $0 }).joined(separator: ", ")
     }
 }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Action.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Action.swift
@@ -20,4 +20,11 @@ extension MelonChartNavigationViewControllerWithAccessibility {
         let size = CGSize(width: view.frame.width - 20, height: cell.frame.height * 2)
         return CGRect(origin: origin, size: size)
     }
+    
+    func configureAccessibilityValue(_ cell: UICollectionViewCell, current index: Int) {
+        let label = samples[index]
+        let value = "총 \(samples.count) 페이지 중 \(index + 1) 페이지"
+        let descriptions = [label, value]
+        cell.accessibilityValue = descriptions.compactMap({ $0 }).joined(separator: ", ")
+    }
 }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Action.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Action.swift
@@ -22,8 +22,8 @@ extension MelonChartNavigationViewControllerWithAccessibility {
     }
     
     func configureAccessibilityValue(_ cell: UICollectionViewCell, current index: Int) {
-        let label = samples[index]
-        let value = "총 \(samples.count) 페이지 중 \(index + 1) 페이지"
+        let label = books[index].title
+        let value = "총 \(books.count) 페이지 중 \(index + 1) 페이지"
         let descriptions = [label, value]
         cell.accessibilityValue = descriptions.compactMap({ $0 }).joined(separator: ", ")
     }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Action.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Action.swift
@@ -46,6 +46,7 @@ extension MelonChartNavigationViewControllerWithAccessibility {
             value = "총 \(books.count) 페이지 중 \(index + 1) 페이지"
         }
         let descriptions = [label, value]
+        cell.accessibilityLabel = nil
         cell.accessibilityValue = descriptions.compactMap({ $0 }).joined(separator: ", ")
     }
 }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Action.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Action.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 extension MelonChartNavigationViewControllerWithAccessibility {
-    func configureAccessibilityFrame(with cell: UICollectionViewCell, for state: AccessibilityFrameState) -> CGRect {
+    func AccessibilityFrameForLatest(with cell: UICollectionViewCell, height: CGFloat, for state: AccessibilityFrameState) -> CGRect {
         let originToView = collectionView.convert(cell.frame.origin, to: view)
         let origin: CGPoint
         switch state {
@@ -17,7 +17,20 @@ extension MelonChartNavigationViewControllerWithAccessibility {
         case .scroll:
             origin = CGPoint(x: originToView.x, y: originToView.y)
         }
-        let size = CGSize(width: view.frame.width - 20, height: cell.frame.height * 2)
+        let size = CGSize(width: view.frame.width - 20, height: cell.frame.height * height)
+        return CGRect(origin: origin, size: size)
+    }
+    
+    func AccessibilityFrameForChart(with cell: UICollectionViewCell, height: CGFloat, for state: AccessibilityFrameState) -> CGRect {
+        let originToView = collectionView.convert(cell.frame.origin, to: view)
+        let origin: CGPoint
+        switch state {
+        case .initial:
+            origin = CGPoint(x: originToView.x, y: originToView.y + collectionView.contentOffset.y - 35)
+        case .scroll:
+            origin = CGPoint(x: originToView.x, y: originToView.y)
+        }
+        let size = CGSize(width: view.frame.width - 20, height: cell.frame.height * height + 10)
         return CGRect(origin: origin, size: size)
     }
     

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Action.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Action.swift
@@ -34,9 +34,17 @@ extension MelonChartNavigationViewControllerWithAccessibility {
         return CGRect(origin: origin, size: size)
     }
     
-    func configureAccessibilityValue(_ cell: UICollectionViewCell, current index: Int) {
-        let label = books[index].title
-        let value = "총 \(books.count) 페이지 중 \(index + 1) 페이지"
+    func configureAccessibilityValue(_ cell: UICollectionViewCell, current index: Int, for section: Section) {
+        let label: String
+        let value: String
+        
+        if section == .latest {
+            label = books[index].title
+            value = "총 \(books.count) 페이지 중 \(index + 1) 페이지"
+        } else {
+            label = "\(index + 1)위, \(books[index].title)"
+            value = "총 \(books.count) 페이지 중 \(index + 1) 페이지"
+        }
         let descriptions = [label, value]
         cell.accessibilityValue = descriptions.compactMap({ $0 }).joined(separator: ", ")
     }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Action.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Action.swift
@@ -1,0 +1,23 @@
+//
+//  MelonChartNavigationViewControllerWithAccessibility+Action.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/14/24.
+//
+
+import UIKit
+
+extension MelonChartNavigationViewControllerWithAccessibility {
+    func configureAccessibilityFrame(with cell: UICollectionViewCell, for state: AccessibilityFrameState) -> CGRect {
+        let originToView = collectionView.convert(cell.frame.origin, to: view)
+        let origin: CGPoint
+        switch state {
+        case .initial:
+            origin = CGPoint(x: originToView.x, y: originToView.y + collectionView.contentOffset.y - 10)
+        case .scroll:
+            origin = CGPoint(x: originToView.x, y: originToView.y)
+        }
+        let size = CGSize(width: view.frame.width - 20, height: cell.frame.height * 2)
+        return CGRect(origin: origin, size: size)
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
@@ -16,7 +16,7 @@ extension MelonChartNavigationViewControllerWithAccessibility {
         
         if indexPath.item == 0 {
             cell.isAccessibilityElement = true
-            cell.accessibilityFrame = configureAccessibilityFrame(with: cell, for: .initial)
+            cell.accessibilityFrame = AccessibilityFrameForLatest(with: cell, height: 2, for: .initial)
             cell.accessibilityLabel = item
             cell.accessibilityValue = "총 \(books.count) 페이지 중 \(indexPath.item + 1) 페이지"
             cell.accessibilityTraits = [.button, .adjustable]
@@ -24,12 +24,18 @@ extension MelonChartNavigationViewControllerWithAccessibility {
         }
     }
     
-    func chartCellRegistrationHandler(cell: UICollectionViewCell, indexPath: IndexPath, item: String) {
-        var config = UIListContentConfiguration.valueCell()
-        config.text = item
-        cell.contentConfiguration = config
-        cell.contentView.layer.borderWidth = 1
-        cell.contentView.layer.borderColor = UIColor.black.cgColor
+    func chartCellRegistrationHandler(cell: BorderedListCell, indexPath: IndexPath, item: String) {
+        cell.rank = indexPath.item + 1
+        cell.text = item
+        
+        if indexPath.item == 0 {
+            cell.isAccessibilityElement = true
+            cell.accessibilityFrame = AccessibilityFrameForChart(with: cell, height: 3, for: .initial)
+            cell.accessibilityLabel = "\(indexPath.item + 1)위, \(item)"
+            cell.accessibilityValue = "총 \(books.count) 페이지 중 \(indexPath.item + 1) 페이지"
+            cell.accessibilityTraits = [.button, .adjustable]
+            cell.delegate = self
+        }
         
     }
     

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
@@ -17,7 +17,7 @@ extension MelonChartNavigationViewControllerWithAccessibility {
         if indexPath.item == 0 {
             cell.isAccessibilityElement = true
             cell.accessibilityFrame = AccessibilityFrameForLatest(with: cell, height: 2, for: .initial)
-            cell.accessibilityLabel = item
+            cell.accessibilityLabel = books[currentPageOfLatest].title
             cell.accessibilityValue = "총 \(books.count) 페이지 중 \(indexPath.item + 1) 페이지"
             cell.accessibilityTraits = [.button, .adjustable]
             cell.delegate = self
@@ -31,7 +31,7 @@ extension MelonChartNavigationViewControllerWithAccessibility {
         if indexPath.item == 0 {
             cell.isAccessibilityElement = true
             cell.accessibilityFrame = AccessibilityFrameForChart(with: cell, height: 3, for: .initial)
-            cell.accessibilityLabel = "\(indexPath.item + 1)위, \(item)"
+            cell.accessibilityLabel = "\(currentPageOfChart + 1)위, \(books[currentPageOfChart].title)"
             cell.accessibilityValue = "총 \(books.count) 페이지 중 \(indexPath.item + 1) 페이지"
             cell.accessibilityTraits = [.button, .adjustable]
             cell.delegate = self
@@ -43,7 +43,7 @@ extension MelonChartNavigationViewControllerWithAccessibility {
         cell.delegate = self
         cell.isAccessibilityElement = true
         cell.accessibilityTraits = [.button, .adjustable]
-        cell.accessibilityLabel = "\(indexPath.item + 1)위, \(books[indexPath.item].title)"
+        cell.accessibilityLabel = "\(currentPageOfCustom + 1)위, \(books[currentPageOfCustom].title)"
         cell.accessibilityValue = "총 \(books.count) 페이지 중 \(currentPageOfCustom + 1) 페이지"
     }
     

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
@@ -39,6 +39,10 @@ extension MelonChartNavigationViewControllerWithAccessibility {
         
     }
     
+    func customCellRegistrationHandler(cell: InnerCollectionListCell, indexPath: IndexPath, item: Bool) {
+        
+    }
+    
     func supplementaryRegistrationHandler(supplementaryView: TitleSupplementaryView, string: String, indexPath: IndexPath) {
         let title = snapshot.sectionIdentifiers[indexPath.section].title
         supplementaryView.title = title
@@ -55,9 +59,10 @@ extension MelonChartNavigationViewControllerWithAccessibility {
         let chartItems = books.map{ Item(chart: $0.title) }
         
         snapshot = Snapshot()
-        snapshot.appendSections([.latest, .chart])
+        snapshot.appendSections([.latest, .chart, .custom])
         snapshot.appendItems(latestItems, toSection: .latest)
         snapshot.appendItems(chartItems, toSection: .chart)
+        snapshot.appendItems([Item(custom: true)], toSection: .custom)
         dataSource.apply(snapshot)
     }
     

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
@@ -1,0 +1,43 @@
+//
+//  MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/13/24.
+//
+
+import UIKit
+
+extension MelonChartNavigationViewControllerWithAccessibility {
+    typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
+    typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Item>
+    
+    func latestCellRegistrationHandler(cell: GridTextCell, indexPath: IndexPath, item: String) {
+        cell.text = item
+    }
+    
+    func chartCellRegistrationHandler(cell: UICollectionViewCell, indexPath: IndexPath, item: String) {
+        var config = UIListContentConfiguration.valueCell()
+        config.text = item
+        cell.contentConfiguration = config
+        cell.contentView.layer.borderWidth = 1
+        cell.contentView.layer.borderColor = UIColor.black.cgColor
+        
+    }
+    
+    func supplementaryRegistrationHandler(supplementaryView: TitleSupplementaryView, string: String, indexPath: IndexPath) {
+        let title = snapshot.sectionIdentifiers[indexPath.section].title
+        supplementaryView.title = title
+    }
+    
+    func updateSnapshot() {
+        let latestItems = ["노래1", "노래2", "노래3", "노래4", "노래5", "노래6", "노래7", "노래8"].map{ Item(latest: $0) }
+        let chartItems = ["노래1", "노래2", "노래3", "노래4", "노래5", "노래6", "노래7", "노래8"].map{ Item(chart: $0) }
+        
+        snapshot = Snapshot()
+        snapshot.appendSections([.latest, .chart])
+        snapshot.appendItems(latestItems, toSection: .latest)
+        snapshot.appendItems(chartItems, toSection: .chart)
+        dataSource.apply(snapshot)
+    }
+    
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
@@ -13,6 +13,15 @@ extension MelonChartNavigationViewControllerWithAccessibility {
     
     func latestCellRegistrationHandler(cell: GridTextCell, indexPath: IndexPath, item: String) {
         cell.text = item
+        cell.isAccessibilityForText = false
+        
+        if indexPath.item == 0 {
+            cell.isAccessibilityElement = true
+            cell.accessibilityFrame = configureAccessibilityFrame(with: cell, for: .initial)
+            cell.accessibilityLabel = item
+            cell.accessibilityValue = "총 \(samples.count) 페이지 중 \(indexPath.item + 1) 페이지"
+            cell.accessibilityTraits = [.button, .adjustable]
+        }
     }
     
     func chartCellRegistrationHandler(cell: UICollectionViewCell, indexPath: IndexPath, item: String) {
@@ -27,11 +36,17 @@ extension MelonChartNavigationViewControllerWithAccessibility {
     func supplementaryRegistrationHandler(supplementaryView: TitleSupplementaryView, string: String, indexPath: IndexPath) {
         let title = snapshot.sectionIdentifiers[indexPath.section].title
         supplementaryView.title = title
+        
+        if UIAccessibility.isVoiceOverRunning {
+            supplementaryView.isAccessibilityElement = true
+            supplementaryView.accessibilityLabel = title
+            supplementaryView.accessibilityTraits = .header
+        }
     }
     
     func updateSnapshot() {
-        let latestItems = ["노래1", "노래2", "노래3", "노래4", "노래5", "노래6", "노래7", "노래8"].map{ Item(latest: $0) }
-        let chartItems = ["노래1", "노래2", "노래3", "노래4", "노래5", "노래6", "노래7", "노래8"].map{ Item(chart: $0) }
+        let latestItems = samples.map{ Item(latest: $0) }
+        let chartItems = samples.map{ Item(chart: $0) }
         
         snapshot = Snapshot()
         snapshot.appendSections([.latest, .chart])

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
@@ -40,7 +40,11 @@ extension MelonChartNavigationViewControllerWithAccessibility {
     }
     
     func customCellRegistrationHandler(cell: InnerCollectionListCell, indexPath: IndexPath, item: Bool) {
-        
+        cell.delegate = self
+        cell.isAccessibilityElement = true
+        cell.accessibilityTraits = [.button, .adjustable]
+        cell.accessibilityLabel = "\(indexPath.item + 1)위, \(books[indexPath.item].title)"
+        cell.accessibilityValue = "총 \(books.count) 페이지 중 \(currentPageOfCustom + 1) 페이지"
     }
     
     func supplementaryRegistrationHandler(supplementaryView: TitleSupplementaryView, string: String, indexPath: IndexPath) {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
@@ -11,9 +11,8 @@ extension MelonChartNavigationViewControllerWithAccessibility {
     typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
     typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Item>
     
-    func latestCellRegistrationHandler(cell: GridTextCell, indexPath: IndexPath, item: String) {
+    func latestCellRegistrationHandler(cell: GridTextCellWithAccessibility, indexPath: IndexPath, item: String) {
         cell.text = item
-        cell.isAccessibilityForText = false
         
         if indexPath.item == 0 {
             cell.isAccessibilityElement = true
@@ -21,6 +20,7 @@ extension MelonChartNavigationViewControllerWithAccessibility {
             cell.accessibilityLabel = item
             cell.accessibilityValue = "총 \(samples.count) 페이지 중 \(indexPath.item + 1) 페이지"
             cell.accessibilityTraits = [.button, .adjustable]
+            cell.delegate = self
         }
     }
     

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+DataSource.swift
@@ -18,7 +18,7 @@ extension MelonChartNavigationViewControllerWithAccessibility {
             cell.isAccessibilityElement = true
             cell.accessibilityFrame = configureAccessibilityFrame(with: cell, for: .initial)
             cell.accessibilityLabel = item
-            cell.accessibilityValue = "총 \(samples.count) 페이지 중 \(indexPath.item + 1) 페이지"
+            cell.accessibilityValue = "총 \(books.count) 페이지 중 \(indexPath.item + 1) 페이지"
             cell.accessibilityTraits = [.button, .adjustable]
             cell.delegate = self
         }
@@ -45,8 +45,8 @@ extension MelonChartNavigationViewControllerWithAccessibility {
     }
     
     func updateSnapshot() {
-        let latestItems = samples.map{ Item(latest: $0) }
-        let chartItems = samples.map{ Item(chart: $0) }
+        let latestItems = books.map{ Item(latest: $0.title) }
+        let chartItems = books.map{ Item(chart: $0.title) }
         
         snapshot = Snapshot()
         snapshot.appendSections([.latest, .chart])

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Delegate.swift
@@ -16,7 +16,7 @@ extension MelonChartNavigationViewControllerWithAccessibility: UIScrollViewDeleg
 
 extension MelonChartNavigationViewControllerWithAccessibility: AdjustableForAccessibilityDelegate {
     func adjustableIncrement(_ view: UICollectionViewCell) {
-        guard currentPageOfLatest < (samples.count - 1) else { return }
+        guard currentPageOfLatest < (books.count - 1) else { return }
         currentPageOfLatest += 1
         configureAccessibilityValue(view, current: currentPageOfLatest)
         

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Delegate.swift
@@ -9,29 +9,55 @@ import UIKit
 
 extension MelonChartNavigationViewControllerWithAccessibility: UIScrollViewDelegate, UICollectionViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard let cell = collectionView.cellForItem(at: IndexPath(item: 0, section: 0)) else { return }
-        cell.accessibilityFrame = configureAccessibilityFrame(with: cell, for: .scroll)
+        guard let cellForLatest = collectionView.cellForItem(at: IndexPath(item: 0, section: 0)),
+              let cellForChart = collectionView.cellForItem(at: IndexPath(item: 0, section: 1)) else { return }
+        cellForLatest.accessibilityFrame = AccessibilityFrameForLatest(with: cellForLatest, height: 2, for: .scroll)
+        cellForChart.accessibilityFrame = AccessibilityFrameForChart(with: cellForChart, height: 3, for: .scroll)
     }
 }
 
-extension MelonChartNavigationViewControllerWithAccessibility: AdjustableForAccessibilityDelegate {
-    func adjustableIncrement(_ view: UICollectionViewCell) {
-        guard currentPageOfLatest < (books.count - 1) else { return }
-        currentPageOfLatest += 1
-        configureAccessibilityValue(view, current: currentPageOfLatest)
-        
-        if currentPageOfLatest != 0, currentPageOfLatest % 4 == 0 {
-            collectionView.scrollToItem(at: IndexPath(item: currentPageOfLatest, section: 0), at: .left, animated: true)
+extension MelonChartNavigationViewControllerWithAccessibility: AdjustableForAccessibility {
+    func adjustableIncrement(_ view: AnyObject) {
+        if view is GridTextCell {
+            guard currentPageOfLatest < (books.count - 1) else { return }
+            currentPageOfLatest += 1
+            configureAccessibilityValue((view as! UICollectionViewCell), current: currentPageOfLatest)
+            
+            if currentPageOfLatest != 0, currentPageOfLatest % 4 == 0 {
+                collectionView.scrollToItem(at: IndexPath(item: currentPageOfLatest, section: 0), at: .left, animated: true)
+            }
+        } else if view is BorderedListCell {
+            guard currentPageOfChart < (books.count - 1) else { return }
+            currentPageOfChart += 1
+            configureAccessibilityValue((view as! UICollectionViewCell), current: currentPageOfChart)
+            
+            if currentPageOfChart != 0, currentPageOfChart % 3 == 0 {
+                collectionView.scrollToItem(at: IndexPath(item: currentPageOfChart, section: 1), at: .left, animated: true)
+            }
+        } else {
+            fatalError("Unknown View")
         }
     }
     
-    func adjustableDecrement(_ view: UICollectionViewCell) {
-        guard currentPageOfLatest > 0 else { return }
-        currentPageOfLatest -= 1
-        configureAccessibilityValue(view, current: currentPageOfLatest)
-        
-        if currentPageOfLatest % 4 == 3 {
-            collectionView.scrollToItem(at: IndexPath(item: currentPageOfLatest, section: 0), at: .right, animated: true)
+    func adjustableDecrement(_ view: AnyObject) {
+        if view is GridTextCell {
+            guard currentPageOfLatest > 0 else { return }
+            currentPageOfLatest -= 1
+            configureAccessibilityValue((view as! UICollectionViewCell), current: currentPageOfLatest)
+            
+            if currentPageOfLatest % 4 == 3 {
+                collectionView.scrollToItem(at: IndexPath(item: currentPageOfLatest, section: 0), at: .right, animated: true)
+            }
+        } else if view is BorderedListCell {
+            guard currentPageOfChart > 0 else { return }
+            currentPageOfChart -= 1
+            configureAccessibilityValue((view as! UICollectionViewCell), current: currentPageOfChart)
+            
+            if currentPageOfChart % 3 == 2 {
+                collectionView.scrollToItem(at: IndexPath(item: currentPageOfChart, section: 1), at: .right, animated: true)
+            }
+        } else {
+            fatalError("Unknown View")
         }
     }
 }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Delegate.swift
@@ -18,10 +18,10 @@ extension MelonChartNavigationViewControllerWithAccessibility: UIScrollViewDeleg
 
 extension MelonChartNavigationViewControllerWithAccessibility: AdjustableForAccessibility {
     func adjustableIncrement(_ view: AnyObject) {
-        if view is GridTextCell {
+        if view is GridTextCellWithAccessibility {
             guard currentPageOfLatest < (books.count - 1) else { return }
             currentPageOfLatest += 1
-            configureAccessibilityValue((view as! UICollectionViewCell), current: currentPageOfLatest)
+            configureAccessibilityValue((view as! UICollectionViewCell), current: currentPageOfLatest, for: .latest)
             
             if currentPageOfLatest != 0, currentPageOfLatest % 4 == 0 {
                 collectionView.scrollToItem(at: IndexPath(item: currentPageOfLatest, section: 0), at: .left, animated: true)
@@ -29,21 +29,27 @@ extension MelonChartNavigationViewControllerWithAccessibility: AdjustableForAcce
         } else if view is BorderedListCell {
             guard currentPageOfChart < (books.count - 1) else { return }
             currentPageOfChart += 1
-            configureAccessibilityValue((view as! UICollectionViewCell), current: currentPageOfChart)
+            configureAccessibilityValue((view as! UICollectionViewCell), current: currentPageOfChart, for: .chart)
             
             if currentPageOfChart != 0, currentPageOfChart % 3 == 0 {
                 collectionView.scrollToItem(at: IndexPath(item: currentPageOfChart, section: 1), at: .left, animated: true)
             }
-        } else {
-            fatalError("Unknown View")
+        } else if let cell = view as? InnerCollectionListCell {
+            guard currentPageOfCustom < (cell.books.count - 1) else { return }
+            currentPageOfCustom += 1
+            configureAccessibilityValue(cell, current: currentPageOfCustom, for: .custom)
+            
+            if currentPageOfCustom != 0, currentPageOfCustom % 2 == 0 {
+                cell.collectionView.scrollToItem(at: IndexPath(item: currentPageOfCustom, section: 0), at: .left, animated: true)
+            }
         }
     }
     
     func adjustableDecrement(_ view: AnyObject) {
-        if view is GridTextCell {
+        if view is GridTextCellWithAccessibility {
             guard currentPageOfLatest > 0 else { return }
             currentPageOfLatest -= 1
-            configureAccessibilityValue((view as! UICollectionViewCell), current: currentPageOfLatest)
+            configureAccessibilityValue((view as! UICollectionViewCell), current: currentPageOfLatest, for: .latest)
             
             if currentPageOfLatest % 4 == 3 {
                 collectionView.scrollToItem(at: IndexPath(item: currentPageOfLatest, section: 0), at: .right, animated: true)
@@ -51,13 +57,19 @@ extension MelonChartNavigationViewControllerWithAccessibility: AdjustableForAcce
         } else if view is BorderedListCell {
             guard currentPageOfChart > 0 else { return }
             currentPageOfChart -= 1
-            configureAccessibilityValue((view as! UICollectionViewCell), current: currentPageOfChart)
+            configureAccessibilityValue((view as! UICollectionViewCell), current: currentPageOfChart, for: .chart)
             
             if currentPageOfChart % 3 == 2 {
                 collectionView.scrollToItem(at: IndexPath(item: currentPageOfChart, section: 1), at: .right, animated: true)
             }
-        } else {
-            fatalError("Unknown View")
-        }
+        } else if let cell = view as? InnerCollectionListCell {
+            guard currentPageOfCustom > 0 else { return }
+            currentPageOfCustom -= 1
+            configureAccessibilityValue(cell, current: currentPageOfCustom, for: .custom)
+            
+            if currentPageOfCustom % 2 == 1 {
+                cell.collectionView.scrollToItem(at: IndexPath(item: currentPageOfCustom, section: 0), at: .right, animated: true)
+            }
+        } 
     }
 }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Delegate.swift
@@ -13,3 +13,25 @@ extension MelonChartNavigationViewControllerWithAccessibility: UIScrollViewDeleg
         cell.accessibilityFrame = configureAccessibilityFrame(with: cell, for: .scroll)
     }
 }
+
+extension MelonChartNavigationViewControllerWithAccessibility: AdjustableForAccessibilityDelegate {
+    func adjustableIncrement(_ view: UICollectionViewCell) {
+        guard currentPageOfLatest < (samples.count - 1) else { return }
+        currentPageOfLatest += 1
+        configureAccessibilityValue(view, current: currentPageOfLatest)
+        
+        if currentPageOfLatest != 0, currentPageOfLatest % 4 == 0 {
+            collectionView.scrollToItem(at: IndexPath(item: currentPageOfLatest, section: 0), at: .left, animated: true)
+        }
+    }
+    
+    func adjustableDecrement(_ view: UICollectionViewCell) {
+        guard currentPageOfLatest > 0 else { return }
+        currentPageOfLatest -= 1
+        configureAccessibilityValue(view, current: currentPageOfLatest)
+        
+        if currentPageOfLatest % 4 == 3 {
+            collectionView.scrollToItem(at: IndexPath(item: currentPageOfLatest, section: 0), at: .right, animated: true)
+        }
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Delegate.swift
@@ -1,0 +1,15 @@
+//
+//  MelonChartNavigationViewControllerWithAccessibility+Delegate.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/14/24.
+//
+
+import UIKit
+
+extension MelonChartNavigationViewControllerWithAccessibility: UIScrollViewDelegate, UICollectionViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard let cell = collectionView.cellForItem(at: IndexPath(item: 0, section: 0)) else { return }
+        cell.accessibilityFrame = configureAccessibilityFrame(with: cell, for: .scroll)
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift
@@ -1,0 +1,75 @@
+//
+//  MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/13/24.
+//
+
+import UIKit
+
+// MARK: CollectionView Layout
+extension MelonChartNavigationViewControllerWithAccessibility {
+    
+    func layout() -> UICollectionViewLayout {
+        let configuration = UICollectionViewCompositionalLayoutConfiguration()
+        configuration.interSectionSpacing = 20
+        return UICollectionViewCompositionalLayout(sectionProvider: sectionProviderHandler, configuration: configuration)
+    }
+    
+    func sectionProviderHandler( sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
+        guard let section = Section(rawValue: sectionIndex) else {
+            fatalError("Unknown Section")
+        }
+        
+        switch section {
+        case .latest:
+            return sectionForLatest()
+        case .chart:
+            return sectionForChart()
+        }
+    }
+    
+    func sectionForLatest() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.48))
+        let nestedGroupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.48), heightDimension: .fractionalHeight(1.0))
+        let containerGroupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.95), heightDimension: .absolute(480))
+        
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let nestedGroup = NSCollectionLayoutGroup.vertical(layoutSize: nestedGroupSize, repeatingSubitem: item, count: 2)
+        nestedGroup.interItemSpacing = NSCollectionLayoutSpacing.fixed(10)
+        
+        let containerGroup = NSCollectionLayoutGroup.horizontal(layoutSize: containerGroupSize, repeatingSubitem: nestedGroup, count: 2)
+        containerGroup.interItemSpacing = NSCollectionLayoutSpacing.fixed(10)
+        
+        let section = NSCollectionLayoutSection(group: containerGroup)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0)
+        section.boundarySupplementaryItems = [titleBoundarySupplementaryItem()]
+        section.orthogonalScrollingBehavior = .continuous
+        
+        return section
+    }
+    
+    func sectionForChart() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.9), heightDimension: .fractionalHeight(0.9))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.9), heightDimension: .estimated(80))
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, repeatingSubitem: item, count: 3)
+        group.interItemSpacing = .fixed(5)
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0)
+        section.boundarySupplementaryItems = [titleBoundarySupplementaryItem()]
+        section.orthogonalScrollingBehavior = .groupPaging
+        
+        return section
+    }
+    
+    func titleBoundarySupplementaryItem() -> NSCollectionLayoutBoundarySupplementaryItem {
+        let titleSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                              heightDimension: .estimated(50))
+        return NSCollectionLayoutBoundarySupplementaryItem(layoutSize: titleSize, elementKind: Supplementary.title
+            .name, alignment: .top)
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+ListLayout.swift
@@ -26,6 +26,8 @@ extension MelonChartNavigationViewControllerWithAccessibility {
             return sectionForLatest()
         case .chart:
             return sectionForChart()
+        case .custom:
+            return sectionForCustom()
         }
     }
     
@@ -62,6 +64,20 @@ extension MelonChartNavigationViewControllerWithAccessibility {
         section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0)
         section.boundarySupplementaryItems = [titleBoundarySupplementaryItem()]
         section.orthogonalScrollingBehavior = .groupPaging
+        
+        return section
+    }
+    
+    func sectionForCustom() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(200))
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0)
+        section.boundarySupplementaryItems = [titleBoundarySupplementaryItem()]
         
         return section
     }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Type.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Type.swift
@@ -10,7 +10,7 @@ import Foundation
 //MARK: Types for DataSource
 extension MelonChartNavigationViewControllerWithAccessibility {
     enum Section: Int {
-        case latest, chart
+        case latest, chart, custom
         
         var title: String {
             switch self {
@@ -18,6 +18,8 @@ extension MelonChartNavigationViewControllerWithAccessibility {
                 return "Latest"
             case .chart:
                 return "Chart"
+            case .custom:
+                return "Custom"
             }
         }
     }
@@ -25,16 +27,26 @@ extension MelonChartNavigationViewControllerWithAccessibility {
     struct Item: Hashable {
         let latest: String?
         let chart: String?
+        let custom: Bool?
         
-        init(latest: String?) {
+        init(latest: String?, chart: String?, custom: Bool?) {
             self.latest = latest
-            self.chart = nil
+            self.chart = chart
+            self.custom = custom
         }
         
-        init(chart: String?) {
-            self.chart = chart
-            self.latest = nil
+        init(latest: String) {
+            self.init(latest: latest, chart: nil, custom: nil)
         }
+        
+        init(chart: String) {
+            self.init(latest: nil, chart: chart, custom: nil)
+        }
+        
+        init(custom: Bool) {
+            self.init(latest: nil, chart: nil, custom: custom)
+        }
+        
     }
     
     enum Supplementary: String {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Type.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Type.swift
@@ -44,4 +44,8 @@ extension MelonChartNavigationViewControllerWithAccessibility {
             self.rawValue
         }
     }
+    
+    enum AccessibilityFrameState {
+        case initial, scroll
+    }
 }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Type.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility+Type.swift
@@ -1,0 +1,47 @@
+//
+//  MelonChartNavigationViewControllerWithAccessibility+Type.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/13/24.
+//
+
+import Foundation
+
+//MARK: Types for DataSource
+extension MelonChartNavigationViewControllerWithAccessibility {
+    enum Section: Int {
+        case latest, chart
+        
+        var title: String {
+            switch self {
+            case .latest:
+                return "Latest"
+            case .chart:
+                return "Chart"
+            }
+        }
+    }
+    
+    struct Item: Hashable {
+        let latest: String?
+        let chart: String?
+        
+        init(latest: String?) {
+            self.latest = latest
+            self.chart = nil
+        }
+        
+        init(chart: String?) {
+            self.chart = chart
+            self.latest = nil
+        }
+    }
+    
+    enum Supplementary: String {
+        case title = "title-element-kind"
+        
+        var name: String {
+            self.rawValue
+        }
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility.swift
@@ -11,8 +11,10 @@ final class MelonChartNavigationViewControllerWithAccessibility: DefaultViewCont
     
     var dataSource: DataSource!
     var snapshot: Snapshot!
+    var accessibilityelements: [Any] = []
+    var samples = ["노래1", "노래2", "노래3", "노래4", "노래5", "노래6", "노래7", "노래8"]
     
-    private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
+    lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
     
     // MARK: LifeCycle
     override func viewDidLoad() {
@@ -28,6 +30,7 @@ final class MelonChartNavigationViewControllerWithAccessibility: DefaultViewCont
 private extension MelonChartNavigationViewControllerWithAccessibility {
     func configureSubviews() {
         collectionView.contentInset = UIEdgeInsets(top: 10, left: 10, bottom: 20, right: -10)
+        collectionView.delegate = self
     }
     
     func configureView() {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility.swift
@@ -42,6 +42,7 @@ private extension MelonChartNavigationViewControllerWithAccessibility {
     func configureDataSource() {
         let latestCellRegistration = UICollectionView.CellRegistration(handler: latestCellRegistrationHandler)
         let chartCellRegistration = UICollectionView.CellRegistration(handler: chartCellRegistrationHandler)
+        let customCellRegistration = UICollectionView.CellRegistration(handler: customCellRegistrationHandler)
         
         dataSource = DataSource(collectionView: collectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
             guard let section = Section(rawValue: indexPath.section) else {
@@ -52,6 +53,8 @@ private extension MelonChartNavigationViewControllerWithAccessibility {
                 return collectionView.dequeueConfiguredReusableCell(using: latestCellRegistration, for: indexPath, item: itemIdentifier.latest)
             case .chart:
                 return collectionView.dequeueConfiguredReusableCell(using: chartCellRegistration, for: indexPath, item: itemIdentifier.chart)
+            case.custom:
+                return collectionView.dequeueConfiguredReusableCell(using: customCellRegistration, for: indexPath, item: itemIdentifier.custom)
             }
         })
         

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility.swift
@@ -13,6 +13,8 @@ final class MelonChartNavigationViewControllerWithAccessibility: DefaultViewCont
     var snapshot: Snapshot!
     var accessibilityelements: [Any] = []
     var samples = ["노래1", "노래2", "노래3", "노래4", "노래5", "노래6", "노래7", "노래8"]
+    var currentPageOfLatest = 0
+    var currentPageOfChart = 0
     
     lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
     

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility.swift
@@ -1,0 +1,62 @@
+//
+//  MelonChartNavigationViewControllerWithAccessibility.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/13/24.
+//
+
+import UIKit
+
+final class MelonChartNavigationViewControllerWithAccessibility: DefaultViewController {
+    
+    var dataSource: DataSource!
+    var snapshot: Snapshot!
+    
+    private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
+    
+    // MARK: LifeCycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        configureSubviews()
+        configureView()
+        configureDataSource()
+    }
+}
+
+// MARK: Configuration
+private extension MelonChartNavigationViewControllerWithAccessibility {
+    func configureSubviews() {
+        collectionView.contentInset = UIEdgeInsets(top: 10, left: 10, bottom: 20, right: -10)
+    }
+    
+    func configureView() {
+        view.addPinnedSubview(collectionView, height: nil)
+    }
+    
+    func configureDataSource() {
+        let latestCellRegistration = UICollectionView.CellRegistration(handler: latestCellRegistrationHandler)
+        let chartCellRegistration = UICollectionView.CellRegistration(handler: chartCellRegistrationHandler)
+        
+        dataSource = DataSource(collectionView: collectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
+            guard let section = Section(rawValue: indexPath.section) else {
+                fatalError("Unknown section")
+            }
+            switch section {
+            case .latest:
+                return collectionView.dequeueConfiguredReusableCell(using: latestCellRegistration, for: indexPath, item: itemIdentifier.latest)
+            case .chart:
+                return collectionView.dequeueConfiguredReusableCell(using: chartCellRegistration, for: indexPath, item: itemIdentifier.chart)
+            }
+        })
+        
+        let supplementaryRegistration = UICollectionView.SupplementaryRegistration(elementKind: Supplementary.title
+            .name, handler: supplementaryRegistrationHandler)
+        dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
+            return collectionView.dequeueConfiguredReusableSupplementary(using: supplementaryRegistration, for: indexPath)
+        }
+        
+        updateSnapshot()
+        collectionView.dataSource = dataSource
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility.swift
@@ -15,6 +15,7 @@ final class MelonChartNavigationViewControllerWithAccessibility: DefaultViewCont
     var books = Book.samples
     var currentPageOfLatest = 0
     var currentPageOfChart = 0
+    var currentPageOfCustom = 0
     
     lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
     

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/List/MelonChartNavigationViewControllerWithAccessibility/MelonChartNavigationViewControllerWithAccessibility.swift
@@ -12,7 +12,7 @@ final class MelonChartNavigationViewControllerWithAccessibility: DefaultViewCont
     var dataSource: DataSource!
     var snapshot: Snapshot!
     var accessibilityelements: [Any] = []
-    var samples = ["노래1", "노래2", "노래3", "노래4", "노래5", "노래6", "노래7", "노래8"]
+    var books = Book.samples
     var currentPageOfLatest = 0
     var currentPageOfChart = 0
     

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Models/Entities/Detail.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Models/Entities/Detail.swift
@@ -65,7 +65,9 @@ extension Detail {
         Detail(title: "UITableView ● 기본 컴포넌트"),
         Detail(title: "UITableView ▲ 개선 컴포넌트"),
         Detail(title: "뉴스 더보기 ● 기본 컴포넌트"),
-        Detail(title: "뉴스 더보기 ▲ 개선 컴포넌트")
+        Detail(title: "뉴스 더보기 ▲ 개선 컴포넌트"),
+        Detail(title: "멜론 차트 탐색 ● 기본 컴포넌트"),
+        Detail(title: "멜론 차트 탐색 ▲ 개선 컴포넌트")
     ]
     
     private static let itemsForPage = [

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Models/Protocols/AdjustableForAccessibility.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Models/Protocols/AdjustableForAccessibility.swift
@@ -1,0 +1,13 @@
+//
+//  AdjustableForAccessibility.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/14/24.
+//
+
+import UIKit
+
+protocol AdjustableForAccessibility: AnyObject {
+    func adjustableIncrement(_ view: AnyObject)
+    func adjustableDecrement(_ view: AnyObject)
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Outline/OutlineViewController/OutLineViewController+Delegate.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Outline/OutlineViewController/OutLineViewController+Delegate.swift
@@ -55,6 +55,10 @@ extension OutlineViewController: UICollectionViewDelegate {
                 vc = NewsListViewController()
             case 5:
                 vc = NewsListViewControllerWithAccessibility()
+            case 6:
+                vc = MelonChartNavigationViewController()
+            case 7:
+                vc = MelonChartNavigationViewControllerWithAccessibility()
             default:
                 return
             }

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/BorderedListCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/BorderedListCell.swift
@@ -1,0 +1,97 @@
+//
+//  BorderedListCell.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/14/24.
+//
+
+import UIKit
+
+class BorderedListCell: UICollectionViewCell, Identifiable {
+    typealias ID = String?
+    
+    weak var delegate: AdjustableForAccessibility?
+    
+    var id: String?
+    
+    var rank: Int! {
+        didSet {
+            rankLabel.text = String(rank)
+        }
+    }
+    var text: String! {
+        didSet {
+            textLabel.text = text
+        }
+    }
+    
+    private lazy var rankLabel = UILabel()
+    private lazy var textLabel = UILabel()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureSubviews()
+        setPreferredFontyStyle()
+        configureContentView()
+        configureConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        rankLabel.text = nil
+        textLabel.text = nil
+    }
+    
+    override func accessibilityIncrement() {
+        delegate?.adjustableIncrement(self)
+        
+    }
+    
+    override func accessibilityDecrement() {
+        delegate?.adjustableDecrement(self)
+    }
+
+}
+
+// MARK: Configuration
+private extension BorderedListCell {
+    func configureSubviews() {
+        rankLabel.font = .systemFont(ofSize: 15, weight: .regular)
+        rankLabel.isAccessibilityElement = false
+        textLabel.font = .systemFont(ofSize: 15, weight: .thin)
+        textLabel.isAccessibilityElement = false
+        contentView.layer.borderWidth = 1
+        contentView.layer.borderColor = UIColor.black.cgColor
+    }
+    
+    func configureContentView() {
+        contentView.addSubviews([rankLabel, textLabel])
+    }
+    
+    func configureConstraints() {
+        let spacing: CGFloat = 5.0
+        let height = contentView.frame.width
+        
+        NSLayoutConstraint.activate([
+            rankLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: spacing),
+            rankLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 10),
+            rankLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            
+            textLabel.centerYAnchor.constraint(equalTo: rankLabel.centerYAnchor),
+            textLabel.leadingAnchor.constraint(equalTo: rankLabel.leadingAnchor, constant: 15),
+            textLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+        ])
+    }
+}
+
+extension BorderedListCell: DynamicTypeable {
+    func setPreferredFontyStyle() {
+        rankLabel.font = UIFont.preferredFont(forTextStyle: .body)
+        textLabel.font = UIFont.preferredFont(forTextStyle: .footnote)
+    }
+}

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/GridTextCell.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/GridTextCell.swift
@@ -28,6 +28,12 @@ class GridTextCell: UICollectionViewCell, Identifiable {
         }
     }
     
+    var isAccessibilityForText: Bool = true {
+        didSet {
+            textLabel.isAccessibilityElement = isAccessibilityForText
+        }
+    }
+    
     private lazy var imageView = UIImageView()
     private lazy var textLabel = UILabel()
     private lazy var secondaryTextLabel = UILabel()

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/GridTextCellWithAccessibility.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/GridTextCellWithAccessibility.swift
@@ -7,16 +7,11 @@
 
 import UIKit
 
-protocol AdjustableForAccessibilityDelegate: AnyObject {
-    func adjustableIncrement(_ view: UICollectionViewCell)
-    func adjustableDecrement(_ view: UICollectionViewCell)
-}
-
 /// Grid shape list cell with text and image
 class GridTextCellWithAccessibility: UICollectionViewCell, Identifiable {
     typealias ID = String?
     
-    weak var delegate: AdjustableForAccessibilityDelegate?
+    weak var delegate: AdjustableForAccessibility?
     
     var id: String?
     var thumbnailImage: UIImage? {

--- a/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/GridTextCellWithAccessibility.swift
+++ b/DefaultComponents-Accessibility/DefaultComponents-Accessibility/Views/GridTextCellWithAccessibility.swift
@@ -1,0 +1,116 @@
+//
+//  GridTextCellWithAccessibility.swift
+//  DefaultComponents-Accessibility
+//
+//  Created by 임윤휘 on 10/14/24.
+//
+
+import UIKit
+
+protocol AdjustableForAccessibilityDelegate: AnyObject {
+    func adjustableIncrement(_ view: UICollectionViewCell)
+    func adjustableDecrement(_ view: UICollectionViewCell)
+}
+
+/// Grid shape list cell with text and image
+class GridTextCellWithAccessibility: UICollectionViewCell, Identifiable {
+    typealias ID = String?
+    
+    weak var delegate: AdjustableForAccessibilityDelegate?
+    
+    var id: String?
+    var thumbnailImage: UIImage? {
+        didSet {
+            imageView.image = thumbnailImage
+        }
+    }
+    var text: String! {
+        didSet {
+            textLabel.text = text
+        }
+    }
+    var secondaryText: String? {
+        didSet {
+            secondaryTextLabel.text = secondaryText
+        }
+    }
+    
+    private lazy var imageView = UIImageView()
+    private lazy var textLabel = UILabel()
+    private lazy var secondaryTextLabel = UILabel()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureSubviews()
+        setPreferredFontyStyle()
+        configureContentView()
+        configureConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        imageView.image = nil
+        textLabel.text = nil
+        secondaryTextLabel.text = nil
+    }
+    
+    override func accessibilityIncrement() {
+        delegate?.adjustableIncrement(self)
+        
+    }
+    
+    override func accessibilityDecrement() {
+        delegate?.adjustableDecrement(self)
+    }
+
+}
+
+// MARK: Configuration
+private extension GridTextCellWithAccessibility {
+    func configureSubviews() {
+        textLabel.isAccessibilityElement = false
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.backgroundColor = .systemGray6
+        
+        textLabel.font = .systemFont(ofSize: 15, weight: .regular)
+        secondaryTextLabel.font = .systemFont(ofSize: 15, weight: .thin)
+    }
+    
+    func configureContentView() {
+        contentView.addSubviews([imageView, textLabel, secondaryTextLabel])
+    }
+    
+    func configureConstraints() {
+        let spacing: CGFloat = 5.0
+        let height = contentView.frame.width
+        
+        NSLayoutConstraint.activate([
+            imageView.heightAnchor.constraint(equalToConstant: height),
+            imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            
+            textLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: spacing),
+            textLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            textLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            
+            secondaryTextLabel.topAnchor.constraint(equalTo: textLabel.bottomAnchor),
+            secondaryTextLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            secondaryTextLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            secondaryTextLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+    }
+}
+
+extension GridTextCellWithAccessibility: DynamicTypeable {
+    func setPreferredFontyStyle() {
+        textLabel.font = UIFont.preferredFont(forTextStyle: .body)
+        secondaryTextLabel.font = UIFont.preferredFont(forTextStyle: .footnote)
+    }
+}


### PR DESCRIPTION
## UI/기능
CompositionalLayout 사용
- 최신 음악(Scroll)
- 멜론 차트(Pagable)

Cell 내 CollectionView 배치
- 커스텀(collection)

## 접근성
- header에 머릿말 특징 설정
- 로터를 통해 아이템 탐색
- 아이템의 위치에 따라 Section 내 Page 이동
- 적절한 안내 메세지 출력

초점
- CompositionalLayout: 첫 번째 Cell의 초점 프레임을 확장
- ColletionView: collectionView을 담은 유일 cell에 초점, 전환 시 내부 collectionView 아이템 탐색

<br>

## ⁉️ 이슈
- CompositionalLayout 버전 초점 프레임 오류


<br>


| 최신곡 | 멜론차트 |
| ----- | ----- |
|  <img src = "https://github.com/user-attachments/assets/c4a2d352-4025-4368-8b75-689d2595fe2e" width = 200 height = 400> | <img src = "https://github.com/user-attachments/assets/ec9d670f-973a-4fea-8776-958341a5f9ea" width = 200 height = 400> |

<br>


#59 
